### PR TITLE
#47 fix: 토큰 재발급 API 경로 수정

### DIFF
--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/controller/AuthController.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/controller/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/auth")
 @RestController
 public class AuthController {
 

--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/common/config/SecurityConfiguration.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/common/config/SecurityConfiguration.java
@@ -31,7 +31,7 @@ public class SecurityConfiguration {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(request -> request.requestMatchers("/oauth2/**", "/auth/**").permitAll()
+                .authorizeHttpRequests(request -> request.requestMatchers("/oauth2/**", "/api/v1/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/parties/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 📌 간단 설명

API 명세에는 /api/v1/auth/tokens로 작성되어 있었지만 /auth/tokens로 구현된 오류를 해결한다.

## ✅ 변경 내용

- AuthController에서 경로 수정(/auth/tokens -> /api/v1/auth/tokens)
- Spring Security 구성에서 /auth/** 대신 /api/v1/auth/**로 수정
