### PR TITLE
#48 refactor: 로그인 시 기존 refresh token 만료

### DIFF
--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/service/AuthService.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/service/AuthService.java
@@ -22,6 +22,7 @@ public class AuthService {
     }
 
     public Tokens issueTokensFor(User user) {
+        refreshTokenProvider.expireRefreshToken(user);
         String accessToken = jwtProvider.issueAccessToken(user);
         String refreshToken = refreshTokenProvider.issueRefreshToken(user);
         return new Tokens(accessToken, refreshToken);

--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/token/RefreshTokenProvider.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/auth/token/RefreshTokenProvider.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -40,6 +42,20 @@ public class RefreshTokenProvider {
         }
         keyValueRepository.remove(key);
         return email;
+    }
+
+    /**
+     * refresh token 만료 ({@code user}의 refresh token을 만료)
+     * @param user {@code null}이 아닌 사용자
+     */
+    public void expireRefreshToken(User user) {
+        String email = user.getEmail();
+        keyValueRepository.getAll()
+                .entrySet()
+                .stream()
+                .filter(entry -> Objects.equals(entry.getValue(), email))
+                .map(Map.Entry::getKey)
+                .forEach(keyValueRepository::remove);
     }
 
     private String generateRefreshToken() {

--- a/storage/db-nosql/src/main/java/com/woopaca/taximate/storage/db/nosql/repository/KeyValueRepository.java
+++ b/storage/db-nosql/src/main/java/com/woopaca/taximate/storage/db/nosql/repository/KeyValueRepository.java
@@ -1,6 +1,7 @@
 package com.woopaca.taximate.storage.db.nosql.repository;
 
 import java.time.Duration;
+import java.util.Map;
 
 public interface KeyValueRepository {
 
@@ -35,4 +36,10 @@ public interface KeyValueRepository {
      * @param key {@code null}이 아닌 문자열
      */
     void remove(String key);
+
+    /**
+     * 모든 키-값 조회
+     * @return {@code null}일 수 없음
+     */
+    Map<String, String> getAll();
 }

--- a/storage/db-nosql/src/main/java/com/woopaca/taximate/storage/db/nosql/repository/RedisKeyValueRepository.java
+++ b/storage/db-nosql/src/main/java/com/woopaca/taximate/storage/db/nosql/repository/RedisKeyValueRepository.java
@@ -7,6 +7,11 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Repository
@@ -45,5 +50,20 @@ public class RedisKeyValueRepository implements KeyValueRepository {
     public void remove(String key) {
         Assert.notNull(key, "key는 null일 수 없습니다.");
         redisTemplate.delete(key);
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        Set<String> keys = redisTemplate.opsForValue()
+                .getOperations()
+                .keys("refresh_token:*");
+        if (Objects.isNull(keys)) {
+            return Collections.emptyMap();
+        }
+        return Objects.requireNonNull(keys).stream()
+                .collect(Collectors.toMap(key -> key, key -> {
+                    String value = redisTemplate.opsForValue().get(key);
+                    return Objects.requireNonNullElse(value, "");
+                }));
     }
 }


### PR DESCRIPTION
## 📌 간단 설명

사용자가 로그인하는 경우 기존 refresh token이 존재한다면 만료시킨다.

## ✅ 변경 내용

- `KeyValueRepository`에 모든 키-값을 `Map<>`으로 반환하는 메서드 추가
- `RefreshTokenProvider`에 사용자의 refresh token을 만료하는 메서드 추가
- `AuthService`의 `issueTokensFor()` 메서드 내에서 사용자의 refresh token을 만료하는 로직 추가
