### PR TITLE
#55 refactor: 팟 참여 API 형식 변경

### DIFF
--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/party/controller/ParticipationController.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/party/controller/ParticipationController.java
@@ -2,11 +2,12 @@ package com.woopaca.taximate.core.api.party.controller;
 
 import com.woopaca.taximate.core.api.common.model.ApiResults;
 import com.woopaca.taximate.core.api.common.model.ApiResults.ApiResponse;
+import com.woopaca.taximate.core.api.party.dto.request.ParticipatePartyRequest;
 import com.woopaca.taximate.core.api.party.dto.response.ParticipatePartyResponse;
 import com.woopaca.taximate.core.domain.party.service.ParticipationService;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/participation")
@@ -20,8 +21,8 @@ public class ParticipationController {
     }
 
     @PostMapping
-    public ApiResponse<ParticipatePartyResponse> participateParty(@RequestParam("partyId") Long partyId) {
-        Long participatedPartyId = participationService.participateParty(partyId);
+    public ApiResponse<ParticipatePartyResponse> participateParty(@RequestBody ParticipatePartyRequest request) {
+        Long participatedPartyId = participationService.participateParty(request.partyId());
         return ApiResults.success(new ParticipatePartyResponse(participatedPartyId));
     }
 }

--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/party/dto/request/ParticipatePartyRequest.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/party/dto/request/ParticipatePartyRequest.java
@@ -1,0 +1,6 @@
+package com.woopaca.taximate.core.api.party.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record ParticipatePartyRequest(@Positive long partyId) {
+}

--- a/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/service/PartyServiceTest.java
+++ b/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/service/PartyServiceTest.java
@@ -5,6 +5,7 @@ import com.woopaca.taximate.core.domain.fixture.ParticipationFixtures;
 import com.woopaca.taximate.core.domain.fixture.PartyFixtures;
 import com.woopaca.taximate.core.domain.fixture.UserFixtures;
 import com.woopaca.taximate.core.domain.local.AddressAllocator;
+import com.woopaca.taximate.core.domain.party.Participation;
 import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.user.User;
 import com.woopaca.taximate.storage.db.core.entity.ParticipationEntity;
@@ -67,7 +68,7 @@ class PartyServiceTest {
 
         @Test
         void 한_사용자가_동시에_많은_팟생성_요청을_해도_최대_개수를_초과하지_않아야_한다() throws InterruptedException {
-            int threadCount = 2;
+            int threadCount = Participation.MAX_PARTICIPATING_PARTIES_COUNT - 1;
             CountDownLatch countDownLatch = new CountDownLatch(threadCount);
             ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 
@@ -86,7 +87,7 @@ class PartyServiceTest {
             countDownLatch.await();
             executorService.shutdown();
 
-            assertThat(partyRepository.count()).isEqualTo(3);
+            assertThat(partyRepository.count()).isEqualTo(Participation.MAX_PARTICIPATING_PARTIES_COUNT);
         }
 
         private void setSecurityContext() {


### PR DESCRIPTION
## 📌 간단 설명

팟 참여 API(`POST /api/v1/participation`)에서 `partyId`를 query parameter 대신 request body로 받도록 변경

## ✅ 변경 내용

- `ParticipationController`의 `participateParty()` 메서드 수정
- `@RequestParam` 대신 `@ReuqestBody`로 변경하고 DTO 추가
- 팟 생성 동시성 테스트에서 매직넘버를 제거하고 상수 사용
