### PR TITLE
#64 feature: 채팅 저장

### DIFF
--- a/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/PartyFinderTest.java
+++ b/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/PartyFinderTest.java
@@ -44,7 +44,7 @@ class PartyFinderTest {
         void 팟_ID로_팟을_찾아서_반환한다() {
             // given
             final long partyId = 1L;
-            when(partyRepository.findById(partyId)).thenReturn(Optional.of(PartyFixtures.createPartyEntity()));
+            when(partyRepository.findByIdWithParticipation(partyId)).thenReturn(Optional.of(PartyFixtures.createPartyEntity()));
 
             // when
             Party party = partyFinder.findParty(partyId);
@@ -57,7 +57,7 @@ class PartyFinderTest {
         void 존재하지_않는_팟_ID로_팟을_찾을_경우_예외가_발생한다() {
             // given
             final long nonexistentId = -1L;
-            when(partyRepository.findById(nonexistentId)).thenReturn(Optional.empty());
+            when(partyRepository.findByIdWithParticipation(nonexistentId)).thenReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> partyFinder.findParty(nonexistentId))

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
@@ -51,27 +51,50 @@ public class Chat {
     }
 
     public static Chat participateMessage(Party party, User participant, LocalDateTime participatedAt) {
-        return systemMessage(party, String.format(PARTICIPATE_MESSAGE, participant.getNickname()), participatedAt);
+        return systemMessage(party, participant, String.format(PARTICIPATE_MESSAGE, participant.getNickname()), participatedAt);
     }
 
     public static Chat leaveMessage(Party party, User leaver, LocalDateTime leftAt) {
-        return systemMessage(party, String.format(LEAVE_MESSAGE, leaver.getNickname()), leftAt);
+        return systemMessage(party, leaver, String.format(LEAVE_MESSAGE, leaver.getNickname()), leftAt);
     }
 
-    private static Chat systemMessage(Party party, String message, LocalDateTime sentAt) {
+    private static Chat systemMessage(Party party, User sender, String message, LocalDateTime sentAt) {
         return Chat.builder()
                 .message(message)
                 .type(MessageType.SYSTEM)
                 .sentAt(sentAt)
+                .sender(sender)
                 .party(party)
                 .build();
     }
 
     public ChatEntity toEntity() {
-        return ChatEntity.builder()
+        ChatEntity.ChatEntityBuilder chatEntityBuilder = ChatEntity.builder()
                 .message(message)
-                .userId(sender != null ? sender.getId() : null)
-                .partyId(party.getId())
+                .type(type.name())
+                .partyId(party.getId());
+        if (sender != null) {
+            chatEntityBuilder.userId(sender.getId());
+        }
+        return chatEntityBuilder.build();
+    }
+
+    public Chat newChat(Long id, Chat chat) {
+        return Chat.builder()
+                .id(id)
+                .message(chat.message)
+                .type(chat.type)
+                .sentAt(chat.sentAt)
+                .sender(chat.sender)
+                .party(chat.party)
                 .build();
+    }
+
+    public boolean isParticipateMessage() {
+        return type.equals(MessageType.SYSTEM) && message.contains(String.format(PARTICIPATE_MESSAGE, ""));
+    }
+
+    public boolean isLeaveMessage() {
+        return type.equals(MessageType.SYSTEM) && message.contains(String.format(LEAVE_MESSAGE, ""));
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 public class Chat {
 
     public static final int MAX_MESSAGE_LENGTH = 500;
+    public static final String PARTICIPATE_MESSAGE = "%s님이 팟에 참여했습니다.";
+    public static final String LEAVE_MESSAGE = "%s님이 팟을 나갔습니다.";
 
     @EqualsAndHashCode.Include
     private Long id;
@@ -48,7 +50,15 @@ public class Chat {
                 .build();
     }
 
-    public static Chat systemMessage(Party party, String message, LocalDateTime sentAt) {
+    public static Chat participateMessage(Party party, User participant, LocalDateTime participatedAt) {
+        return systemMessage(party, String.format(PARTICIPATE_MESSAGE, participant.getNickname()), participatedAt);
+    }
+
+    public static Chat leaveMessage(Party party, User leaver, LocalDateTime leftAt) {
+        return systemMessage(party, String.format(LEAVE_MESSAGE, leaver.getNickname()), leftAt);
+    }
+
+    private static Chat systemMessage(Party party, String message, LocalDateTime sentAt) {
         return Chat.builder()
                 .message(message)
                 .type(MessageType.SYSTEM)

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
@@ -1,5 +1,6 @@
 package com.woopaca.taximate.core.domain.chat;
 
+import com.woopaca.taximate.core.domain.chat.id.IdGenerator;
 import com.woopaca.taximate.core.domain.error.exception.ChatMessageTooLongException;
 import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.user.User;
@@ -27,12 +28,12 @@ public class Chat {
     private Party party;
 
     @Builder
-    public Chat(Long id, String message, MessageType type, LocalDateTime sentAt, User sender, Party party) {
+    public Chat(String message, MessageType type, LocalDateTime sentAt, User sender, Party party) {
         if (message.length() > MAX_MESSAGE_LENGTH) {
             throw new ChatMessageTooLongException();
         }
 
-        this.id = id;
+        this.id = IdGenerator.generateId();
         this.message = message.trim();
         this.type = type;
         this.sentAt = sentAt;
@@ -70,6 +71,7 @@ public class Chat {
 
     public ChatEntity toEntity() {
         ChatEntity.ChatEntityBuilder chatEntityBuilder = ChatEntity.builder()
+                .id(id)
                 .message(message)
                 .type(type.name())
                 .partyId(party.getId());
@@ -77,17 +79,6 @@ public class Chat {
             chatEntityBuilder.userId(sender.getId());
         }
         return chatEntityBuilder.build();
-    }
-
-    public Chat newChat(Long id, Chat chat) {
-        return Chat.builder()
-                .id(id)
-                .message(chat.message)
-                .type(chat.type)
-                .sentAt(chat.sentAt)
-                .sender(chat.sender)
-                .party(chat.party)
-                .build();
     }
 
     public boolean isParticipateMessage() {

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
@@ -3,6 +3,7 @@ package com.woopaca.taximate.core.domain.chat;
 import com.woopaca.taximate.core.domain.error.exception.ChatMessageTooLongException;
 import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.user.User;
+import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -30,7 +31,7 @@ public class Chat {
         }
 
         this.id = id;
-        this.message = message;
+        this.message = message.trim();
         this.type = type;
         this.sentAt = sentAt;
         this.sender = sender;
@@ -53,6 +54,14 @@ public class Chat {
                 .type(MessageType.SYSTEM)
                 .sentAt(sentAt)
                 .party(party)
+                .build();
+    }
+
+    public ChatEntity toEntity() {
+        return ChatEntity.builder()
+                .message(message)
+                .userId(sender.getId())
+                .partyId(party.getId())
                 .build();
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/Chat.java
@@ -60,7 +60,7 @@ public class Chat {
     public ChatEntity toEntity() {
         return ChatEntity.builder()
                 .message(message)
-                .userId(sender.getId())
+                .userId(sender != null ? sender.getId() : null)
                 .partyId(party.getId())
                 .build();
     }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
@@ -15,9 +15,8 @@ public class ChatAppender {
         this.chatRepository = chatRepository;
     }
 
-    public Chat appendNew(Chat chat) {
+    public void appendNew(Chat chat) {
         ChatEntity chatEntity = chat.toEntity();
-        ChatEntity savedChatEntity = chatRepository.save(chatEntity);
-        return chat.newChat(savedChatEntity.getId(), chat);
+        chatRepository.save(chatEntity);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
@@ -1,0 +1,22 @@
+package com.woopaca.taximate.core.domain.chat;
+
+import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
+import com.woopaca.taximate.storage.db.core.repository.ChatRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ChatAppender {
+
+    private final ChatRepository chatRepository;
+
+    public ChatAppender(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    public void appendChat(Chat chat) {
+        ChatEntity chatEntity = chat.toEntity();
+        chatRepository.save(chatEntity);
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
@@ -15,8 +15,9 @@ public class ChatAppender {
         this.chatRepository = chatRepository;
     }
 
-    public void appendChat(Chat chat) {
+    public Chat appendNew(Chat chat) {
         ChatEntity chatEntity = chat.toEntity();
-        chatRepository.save(chatEntity);
+        ChatEntity savedChatEntity = chatRepository.save(chatEntity);
+        return chat.newChat(savedChatEntity.getId(), chat);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
@@ -1,0 +1,47 @@
+package com.woopaca.taximate.core.domain.chat;
+
+import com.woopaca.taximate.core.domain.party.Party;
+import com.woopaca.taximate.core.domain.user.User;
+import com.woopaca.taximate.storage.db.core.entity.ChatReadEntity;
+import com.woopaca.taximate.storage.db.core.repository.ChatReadRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatReadRecorder {
+
+    private final ChatReadRepository chatReadRepository;
+
+    public ChatReadRecorder(ChatReadRepository chatReadRepository) {
+        this.chatReadRepository = chatReadRepository;
+    }
+
+    public void createReadHistory(Chat participateChat) {
+        User user = participateChat.getSender();
+        Party party = participateChat.getParty();
+        ChatReadEntity chatReadEntity = ChatReadEntity.builder()
+                .userId(user.getId())
+                .partyId(party.getId())
+                .lastChatId(participateChat.getId())
+                .build();
+        chatReadRepository.save(chatReadEntity);
+    }
+
+    public void removeReadHistory(Chat leaveChat) {
+        User user = leaveChat.getSender();
+        Party party = leaveChat.getParty();
+        chatReadRepository.findByUserIdAndPartyId(user.getId(), party.getId())
+                .ifPresent(chatReadRepository::delete);
+    }
+
+    public void recordReadHistory(Chat chat) {
+        recordReadHistory(chat, chat.getSender());
+    }
+
+    public void recordReadHistory(Chat chat, User user) {
+        chatReadRepository.findByUserIdAndPartyId(user.getId(), chat.getParty().getId())
+                .ifPresent(entity -> {
+                    entity.updateLastChatId(chat.getId());
+                    chatReadRepository.save(entity);
+                });
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/id/IdGenerator.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/id/IdGenerator.java
@@ -1,0 +1,26 @@
+package com.woopaca.taximate.core.domain.chat.id;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class IdGenerator {
+
+    private final AtomicLong sequence = new AtomicLong(0);
+
+    private IdGenerator() {
+    }
+
+    private static class Nested {
+
+        static final IdGenerator INSTANCE = new IdGenerator();
+    }
+
+    static void setInitialId(long initialId) {
+        IdGenerator instance = Nested.INSTANCE;
+        instance.sequence.set(initialId);
+    }
+
+    public static long generateId() {
+        IdGenerator instance = Nested.INSTANCE;
+        return instance.sequence.incrementAndGet();
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/id/IdGeneratorConfiguration.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/id/IdGeneratorConfiguration.java
@@ -1,0 +1,23 @@
+package com.woopaca.taximate.core.domain.chat.id;
+
+import com.woopaca.taximate.storage.db.core.repository.ChatRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+
+@Configuration
+public class IdGeneratorConfiguration {
+
+    private final ChatRepository chatRepository;
+
+    public IdGeneratorConfiguration(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        chatRepository.findTopBy(Sort.by(Order.desc("id")))
+                .ifPresent(entity -> IdGenerator.setInitialId(entity.getId()));
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.woopaca.taximate.core.domain.chat.service;
 
 import com.woopaca.taximate.core.domain.chat.Chat;
 import com.woopaca.taximate.core.domain.chat.MessageNotifier;
+import com.woopaca.taximate.core.domain.error.exception.NotParticipatedPartyException;
 import com.woopaca.taximate.core.domain.event.ChatEventProducer;
 import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.party.PartyFinder;
@@ -23,6 +24,9 @@ public class ChatService {
 
     public void sendStandardMessage(Long partyId, User sender, String message) {
         Party party = partyFinder.findParty(partyId);
+        if (!party.isParticipated(sender)) {
+            throw new NotParticipatedPartyException();
+        }
         Chat chat = Chat.standardMessage(party, sender, message);
         chatEventProducer.publishChatEvent(chat);
         messageNotifier.notify(chat);

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/ErrorType.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/ErrorType.java
@@ -26,7 +26,9 @@ public enum ErrorType {
 
     MESSAGE_TOO_LONG("", ErrorHttpStatus.BAD_REQUEST),
 
-    INVALID_REFRESH_TOKEN("", ErrorHttpStatus.UNAUTHORIZED);
+    INVALID_REFRESH_TOKEN("", ErrorHttpStatus.UNAUTHORIZED),
+
+    NOT_PARTICIPATED_PARTY("", ErrorHttpStatus.FORBIDDEN);
 
     private final String errorCode;
     private final ErrorHttpStatus errorHttpStatus;
@@ -41,7 +43,8 @@ public enum ErrorType {
 
         BAD_REQUEST(400, "Bad Request"),
         UNAUTHORIZED(401, "Unauthorized"),
-        NOT_FOUND(404, "Not Found");
+        NOT_FOUND(404, "Not Found"),
+        FORBIDDEN(403, "Forbidden");
 
         private final int value;
         private final String reasonPhrase;

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/exception/NotParticipatedPartyException.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/exception/NotParticipatedPartyException.java
@@ -1,0 +1,12 @@
+package com.woopaca.taximate.core.domain.error.exception;
+
+import com.woopaca.taximate.core.domain.error.ErrorType;
+
+public class NotParticipatedPartyException extends BusinessException {
+
+    private static final String MESSAGE = "참여하지 않은 팟입니다.";
+
+    public NotParticipatedPartyException() {
+        super(MESSAGE, ErrorType.NOT_PARTICIPATED_PARTY);
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
@@ -20,15 +20,16 @@ public class ChatEventConsumer {
 
     @EventListener
     public void handleChatEvent(ChatEvent chatEvent) {
-        Chat newChat = chatAppender.appendNew(chatEvent.chat());
-        if (newChat.isParticipateMessage()) {
-            chatReadRecorder.createReadHistory(newChat);
+        Chat chat = chatEvent.chat();
+        chatAppender.appendNew(chat);
+        if (chat.isParticipateMessage()) {
+            chatReadRecorder.createReadHistory(chat);
             return;
         }
-        if (newChat.isLeaveMessage()) {
-            chatReadRecorder.removeReadHistory(newChat);
+        if (chat.isLeaveMessage()) {
+            chatReadRecorder.removeReadHistory(chat);
             return;
         }
-        chatReadRecorder.recordReadHistory(newChat);
+        chatReadRecorder.recordReadHistory(chat);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
@@ -1,6 +1,8 @@
 package com.woopaca.taximate.core.domain.event;
 
+import com.woopaca.taximate.core.domain.chat.Chat;
 import com.woopaca.taximate.core.domain.chat.ChatAppender;
+import com.woopaca.taximate.core.domain.chat.ChatReadRecorder;
 import com.woopaca.taximate.core.domain.event.dto.ChatEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -9,13 +11,24 @@ import org.springframework.stereotype.Component;
 public class ChatEventConsumer {
 
     private final ChatAppender chatAppender;
+    private final ChatReadRecorder chatReadRecorder;
 
-    public ChatEventConsumer(ChatAppender chatAppender) {
+    public ChatEventConsumer(ChatAppender chatAppender, ChatReadRecorder chatReadRecorder) {
         this.chatAppender = chatAppender;
+        this.chatReadRecorder = chatReadRecorder;
     }
 
     @EventListener
     public void handleChatEvent(ChatEvent chatEvent) {
-        chatAppender.appendChat(chatEvent.chat());
+        Chat newChat = chatAppender.appendNew(chatEvent.chat());
+        if (newChat.isParticipateMessage()) {
+            chatReadRecorder.createReadHistory(newChat);
+            return;
+        }
+        if (newChat.isLeaveMessage()) {
+            chatReadRecorder.removeReadHistory(newChat);
+            return;
+        }
+        chatReadRecorder.recordReadHistory(newChat);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
@@ -1,0 +1,21 @@
+package com.woopaca.taximate.core.domain.event;
+
+import com.woopaca.taximate.core.domain.chat.ChatAppender;
+import com.woopaca.taximate.core.domain.event.dto.ChatEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatEventConsumer {
+
+    private final ChatAppender chatAppender;
+
+    public ChatEventConsumer(ChatAppender chatAppender) {
+        this.chatAppender = chatAppender;
+    }
+
+    @EventListener
+    public void handleChatEvent(ChatEvent chatEvent) {
+        chatAppender.appendChat(chatEvent.chat());
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventProducer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventProducer.java
@@ -16,7 +16,7 @@ public class ChatEventProducer {
         this.eventPublisher = eventPublisher;
     }
 
-    public void publishChatEvent(Chat chat) { // TODO consumer는 이벤트를 받아 DB에 채팅을 저장하는 로직 수행
+    public void publishChatEvent(Chat chat) {
         ChatEvent event = new ChatEvent(chat);
         eventPublisher.publishEvent(event);
     }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class ParticipationEventConsumer {
 
-    private static final String PARTICIPATE_MESSAGE = "%s님이 팟에 참여하였습니다.";
+    private static final String PARTICIPATE_MESSAGE = "%s님이 팟에 참여했습니다.";
     private static final String LEAVE_MESSAGE = "%s님이 팟을 나갔습니다.";
 
     private final ChatEventProducer chatEventProducer;

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
@@ -15,8 +15,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class ParticipationEventConsumer {
 
-    private static final String PARTICIPATE_MESSAGE = "%s님이 참여하였습니다.";
-    private static final String LEAVE_MESSAGE = "%s님이 나갔습니다.";
+    private static final String PARTICIPATE_MESSAGE = "%s님이 팟에 참여하였습니다.";
+    private static final String LEAVE_MESSAGE = "%s님이 팟을 나갔습니다.";
 
     private final ChatEventProducer chatEventProducer;
     private final MessageNotifier messageNotifier;

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ParticipationEventConsumer.java
@@ -15,9 +15,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class ParticipationEventConsumer {
 
-    private static final String PARTICIPATE_MESSAGE = "%s님이 팟에 참여했습니다.";
-    private static final String LEAVE_MESSAGE = "%s님이 팟을 나갔습니다.";
-
     private final ChatEventProducer chatEventProducer;
     private final MessageNotifier messageNotifier;
 
@@ -30,21 +27,19 @@ public class ParticipationEventConsumer {
     @TransactionalEventListener
     public void handleParticipateEvent(ParticipateEvent participateEvent) {
         User participant = participateEvent.participant();
-        String message = String.format(PARTICIPATE_MESSAGE, participant.getNickname());
         Party party = participateEvent.party();
-        Chat systemMessage = Chat.systemMessage(party, message, participateEvent.participatedAt());
-        chatEventProducer.publishChatEvent(systemMessage);
-        messageNotifier.notify(systemMessage);
+        Chat participateMessage = Chat.participateMessage(party, participant, participateEvent.participatedAt());
+        chatEventProducer.publishChatEvent(participateMessage);
+        messageNotifier.notify(participateMessage);
     }
 
     @Async
     @TransactionalEventListener
     public void handleLeaveEvent(LeaveEvent leaveEvent) {
         User leaver = leaveEvent.leaver();
-        String message = String.format(LEAVE_MESSAGE, leaver.getNickname());
         Party party = leaveEvent.party();
-        Chat systemMessage = Chat.systemMessage(party, message, leaveEvent.leftAt());
-        chatEventProducer.publishChatEvent(systemMessage);
-        messageNotifier.notify(systemMessage);
+        Chat leaveMessage = Chat.leaveMessage(party, leaver, leaveEvent.leftAt());
+        chatEventProducer.publishChatEvent(leaveMessage);
+        messageNotifier.notify(leaveMessage);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/ParticipationAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/ParticipationAppender.java
@@ -22,16 +22,17 @@ public class ParticipationAppender {
         this.partyRepository = partyRepository;
     }
 
-    public void appendHost(Long partyId, User user) {
-        PartyEntity partyEntity = partyRepository.findById(partyId)
-                .orElseThrow(() -> new NonexistentPartyException(partyId));
+    public Participation appendHost(Party party, User user) {
+        PartyEntity partyEntity = partyRepository.findById(party.getId())
+                .orElseThrow(() -> new NonexistentPartyException(party.getId()));
         ParticipationEntity participationEntity = ParticipationEntity.builder()
                 .role(ParticipationRole.HOST.name())
                 .userId(user.getId())
                 .party(partyEntity)
                 .status(ParticipationStatus.PARTICIPATING.name())
                 .build();
-        participationRepository.save(participationEntity);
+        ParticipationEntity savedParticipationEntity = participationRepository.save(participationEntity);
+        return Participation.fromEntity(savedParticipationEntity);
     }
 
     public Participation appendParticipant(Party party, User user) {

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyAppender.java
@@ -13,7 +13,7 @@ public class PartyAppender {
         this.partyRepository = partyRepository;
     }
 
-    public Long appendNew(Party party) {
+    public Party appendNew(Party party) {
         PartyEntity partyEntity = PartyEntity.builder()
                 .title(party.getTitle())
                 .explanation(party.getExplanation())
@@ -29,6 +29,6 @@ public class PartyAppender {
                 .maxParticipants(party.getMaxParticipants())
                 .build();
         PartyEntity savedPartyEntity = partyRepository.save(partyEntity);
-        return savedPartyEntity.getId();
+        return Party.fromEntity(savedPartyEntity);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
@@ -27,6 +27,12 @@ public class PartyFinder {
         return Party.fromEntity(partyEntity);
     }
 
+    public Party findPartyWithParticipation(Long partyId) {
+        PartyEntity partyEntity = partyRepository.findByIdWithParticipation(partyId)
+                .orElseThrow(() -> new NonexistentPartyException(partyId));
+        return Party.fromEntity(partyEntity);
+    }
+
     public Party findPartyWithLock(Long partyId) {
         PartyEntity partyEntity = partyRepository.findByIdForUpdate(partyId)
                 .orElseThrow(() -> new NonexistentPartyException(partyId));

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
@@ -22,12 +22,6 @@ public class PartyFinder {
     }
 
     public Party findParty(Long partyId) {
-        PartyEntity partyEntity = partyRepository.findById(partyId)
-                .orElseThrow(() -> new NonexistentPartyException(partyId));
-        return Party.fromEntity(partyEntity);
-    }
-
-    public Party findPartyWithParticipation(Long partyId) {
         PartyEntity partyEntity = partyRepository.findByIdWithParticipation(partyId)
                 .orElseThrow(() -> new NonexistentPartyException(partyId));
         return Party.fromEntity(partyEntity);

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/service/PartyValidator.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/service/PartyValidator.java
@@ -38,8 +38,8 @@ public class PartyValidator {
     public void validateParticipateParty(Party party, User participant) {
         validateProgress(party);
         validateAlreadyParticipated(party, participant);
-        validateMaxParticipationCount(participant);
         validateParticipantsFull(party);
+        validateMaxParticipationCount(participant);
     }
 
     private void validateContents(Party party) {

--- a/core/core-message/src/main/java/com/woopaca/taximate/core/message/dto/ChatMessage.java
+++ b/core/core-message/src/main/java/com/woopaca/taximate/core/message/dto/ChatMessage.java
@@ -12,13 +12,6 @@ public record ChatMessage(Long partyId, String partyTitle, String message, Messa
                           Sender sender) {
 
     public static ChatMessage from(Chat chat) {
-        if (chat.getParty() == null) {
-            return ChatMessage.builder()
-                    .message(chat.getMessage())
-                    .createdAt(chat.getSentAt())
-                    .build();
-        }
-
         return ChatMessage.builder()
                 .partyId(chat.getParty().getId())
                 .partyTitle(chat.getParty().getTitle())

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
@@ -1,0 +1,26 @@
+package com.woopaca.taximate.storage.db.core.entity;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity(name = "chat")
+public class ChatEntity extends BaseEntity {
+
+    private String message;
+
+    private Long userId;
+
+    private Long partyId;
+
+    public ChatEntity() {
+    }
+
+    @Builder
+    public ChatEntity(String message, Long userId, Long partyId) {
+        this.message = message;
+        this.userId = userId;
+        this.partyId = partyId;
+    }
+}

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
@@ -1,12 +1,23 @@
 package com.woopaca.taximate.storage.db.core.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @Entity(name = "chat")
-public class ChatEntity extends BaseEntity {
+public class ChatEntity {
+
+    @Id
+    private Long id;
 
     private String message;
 
@@ -16,11 +27,18 @@ public class ChatEntity extends BaseEntity {
 
     private Long partyId;
 
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
     public ChatEntity() {
     }
 
     @Builder
-    public ChatEntity(String message, String type, Long userId, Long partyId) {
+    public ChatEntity(Long id, String message, String type, Long userId, Long partyId) {
+        this.id = id;
         this.message = message;
         this.type = type;
         this.userId = userId;

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
@@ -10,6 +10,8 @@ public class ChatEntity extends BaseEntity {
 
     private String message;
 
+    private String type;
+
     private Long userId;
 
     private Long partyId;
@@ -18,8 +20,9 @@ public class ChatEntity extends BaseEntity {
     }
 
     @Builder
-    public ChatEntity(String message, Long userId, Long partyId) {
+    public ChatEntity(String message, String type, Long userId, Long partyId) {
         this.message = message;
+        this.type = type;
         this.userId = userId;
         this.partyId = partyId;
     }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatReadEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatReadEntity.java
@@ -1,0 +1,32 @@
+package com.woopaca.taximate.storage.db.core.entity;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity(name = "chat_read")
+public class ChatReadEntity extends BaseEntity {
+
+    private Long userId;
+
+    private Long partyId;
+
+    private Long lastChatId;
+
+    public ChatReadEntity() {
+    }
+
+    @Builder
+    public ChatReadEntity(Long userId, Long partyId, Long lastChatId) {
+        this.userId = userId;
+        this.partyId = partyId;
+        this.lastChatId = lastChatId;
+    }
+
+    public void updateLastChatId(Long readChatId) {
+        if (lastChatId < readChatId) {
+            lastChatId = readChatId;
+        }
+    }
+}

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/PartyEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/PartyEntity.java
@@ -1,7 +1,6 @@
 package com.woopaca.taximate.storage.db.core.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,13 +8,11 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Set;
 
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Entity(name = "party")
 public class PartyEntity extends BaseEntity {

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
@@ -1,0 +1,13 @@
+package com.woopaca.taximate.storage.db.core.repository;
+
+import com.woopaca.taximate.storage.db.core.entity.ChatReadEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChatReadRepository extends JpaRepository<ChatReadEntity, Long> {
+
+    Optional<ChatReadEntity> findByUserIdAndPartyId(Long userId, Long partyId);
+}

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
@@ -1,9 +1,14 @@
 package com.woopaca.taximate.storage.db.core.repository;
 
 import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
+
+    Optional<ChatEntity> findTopBy(Sort sort);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
@@ -1,0 +1,9 @@
+package com.woopaca.taximate.storage.db.core.repository;
+
+import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
+}

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
@@ -1,9 +1,22 @@
 package com.woopaca.taximate.storage.db.core.repository;
 
 import com.woopaca.taximate.storage.db.core.entity.PartyEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PartyRepository extends JpaRepository<PartyEntity, Long>, PartyQueryDslRepository {
+
+    @EntityGraph(attributePaths = {"participationSet"})
+    @Query("""
+            SELECT p
+            FROM com.woopaca.taximate.storage.db.core.entity.PartyEntity p
+            WHERE p.id = :id
+            """)
+    Optional<PartyEntity> findByIdWithParticipation(@Param("id") Long id);
 }

--- a/storage/db-core/src/main/resources/db/schema.sql
+++ b/storage/db-core/src/main/resources/db/schema.sql
@@ -52,3 +52,27 @@ CREATE TABLE IF NOT EXISTS `participation`
 CREATE INDEX `idx_party_id` ON `participation` (`party_id`);
 
 CREATE INDEX `idx_user_id` ON `participation` (`user_id`);
+
+CREATE TABLE IF NOT EXISTS `chat`
+(
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT,
+    `message`    VARCHAR(500) NOT NULL,
+    `user_id`    BIGINT,
+    `party_id`   BIGINT       NOT NULL,
+    `created_at` DATETIME     NOT NULL,
+    `updated_at` DATETIME     NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE INDEX `idx_party_id` ON `chat` (`party_id`);
+
+CREATE TABLE IF NOT EXISTS `chat_read`
+(
+    `id`           BIGINT NOT NULL AUTO_INCREMENT,
+    `user_id`      BIGINT NOT NULL,
+    `party_id`     BIGINT NOT NULL,
+    `last_chat_id` BIGINT NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE INDEX `idx_user_id_party_id` ON `chat_read` (`user_id`, `party_id`);

--- a/storage/db-core/src/main/resources/db/schema.sql
+++ b/storage/db-core/src/main/resources/db/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS `chat`
 (
     `id`         BIGINT       NOT NULL AUTO_INCREMENT,
     `message`    VARCHAR(500) NOT NULL,
+    `type`       VARCHAR(20)  NOT NULL,
     `user_id`    BIGINT,
     `party_id`   BIGINT       NOT NULL,
     `created_at` DATETIME     NOT NULL,
@@ -68,11 +69,13 @@ CREATE INDEX `idx_party_id` ON `chat` (`party_id`);
 
 CREATE TABLE IF NOT EXISTS `chat_read`
 (
-    `id`           BIGINT NOT NULL AUTO_INCREMENT,
-    `user_id`      BIGINT NOT NULL,
-    `party_id`     BIGINT NOT NULL,
-    `last_chat_id` BIGINT NOT NULL,
+    `id`           BIGINT   NOT NULL AUTO_INCREMENT,
+    `user_id`      BIGINT   NOT NULL,
+    `party_id`     BIGINT   NOT NULL,
+    `last_chat_id` BIGINT   NOT NULL,
+    `created_at`   DATETIME NOT NULL,
+    `updated_at`   DATETIME NOT NULL,
     PRIMARY KEY (`id`)
 );
 
-CREATE INDEX `idx_user_id_party_id` ON `chat_read` (`user_id`, `party_id`);
+CREATE UNIQUE INDEX `uidx_user_id_party_id` ON `chat_read` (`user_id`, `party_id`);


### PR DESCRIPTION
## 📌 간단 설명

채팅을 DB에 저장한다.

## ✅ 변경 내용

- 시스템 메시지, 사용자 메시지가 전송되면 DB에 저장
  - 지금은 단순히 RDBMS에 저장하지만 추후 NoSQL 마이그레이션 고려
- 메시지 전송 시 채팅 읽음 기록 갱신
