### PR TITLE
#66 feature: 채팅방 목록 조회 API

### DIFF
--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/controller/ChatApiController.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/controller/ChatApiController.java
@@ -1,0 +1,31 @@
+package com.woopaca.taximate.core.api.chat.controller;
+
+import com.woopaca.taximate.core.api.chat.dto.ChatRoomResponse;
+import com.woopaca.taximate.core.api.common.model.ApiResults;
+import com.woopaca.taximate.core.api.common.model.ApiResults.ApiResponse;
+import com.woopaca.taximate.core.domain.chat.service.ChatService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/v1/chat")
+@RestController
+public class ChatApiController {
+
+    private final ChatService chatService;
+
+    public ChatApiController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<ChatRoomResponse>> chatRoomList() {
+        List<ChatRoomResponse> response = chatService.getChatRoomList()
+                .stream()
+                .map(ChatRoomResponse::from)
+                .toList();
+        return ApiResults.success(response);
+    }
+}

--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/dto/ChatRoomResponse.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,29 @@
+package com.woopaca.taximate.core.api.chat.dto;
+
+import com.woopaca.taximate.core.domain.chat.Chat;
+import com.woopaca.taximate.core.domain.chat.ChatRoom;
+import com.woopaca.taximate.core.domain.party.Party;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatRoomResponse(Long id, String title, int maxParticipants, int currentParticipants, boolean isProgress,
+                               String recentMessage, LocalDateTime recentMessageTime, int unreadCount) {
+
+    public static ChatRoomResponse from(ChatRoom chatRoom) {
+        Party party = chatRoom.getParty();
+        Chat recentMessage = chatRoom.getRecentMessage();
+        int unreadCount = chatRoom.getUnreadCount();
+        return ChatRoomResponse.builder()
+                .id(party.getId())
+                .title(party.getTitle())
+                .maxParticipants(party.getMaxParticipants())
+                .currentParticipants(party.currentParticipantsCount())
+                .isProgress(party.isProgress())
+                .recentMessage(recentMessage.getMessage())
+                .recentMessageTime(recentMessage.getSentAt())
+                .unreadCount(unreadCount)
+                .build();
+    }
+}

--- a/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/PartyFinderTest.java
+++ b/core/core-api/src/test/java/com/woopaca/taximate/core/domain/party/PartyFinderTest.java
@@ -1,11 +1,9 @@
 package com.woopaca.taximate.core.domain.party;
 
 import com.woopaca.taximate.core.domain.error.exception.NonexistentPartyException;
-import com.woopaca.taximate.core.domain.fixture.ParticipationFixtures;
 import com.woopaca.taximate.core.domain.fixture.PartyFixtures;
 import com.woopaca.taximate.core.domain.fixture.UserFixtures;
-import com.woopaca.taximate.storage.db.core.entity.ParticipationEntity;
-import com.woopaca.taximate.storage.db.core.repository.ParticipationRepository;
+import com.woopaca.taximate.storage.db.core.entity.PartyEntity;
 import com.woopaca.taximate.storage.db.core.repository.PartyRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -34,8 +32,6 @@ class PartyFinderTest {
 
     @Mock
     private PartyRepository partyRepository;
-    @Mock
-    private ParticipationRepository participationRepository;
 
     @Nested
     class findParty_메서드는 {
@@ -97,15 +93,16 @@ class PartyFinderTest {
     class findParticipatingParties_메서드는 {
 
         @Test
-        void 참여중인_팟을_찾아서_반환한다() {
+        void 종료되지_않은_참여중인_팟을_찾아서_반환한다() {
             // given
             final long userId = 1L;
             final int partiesSize = 2;
-            List<ParticipationEntity> participationEntities = IntStream.rangeClosed(1, partiesSize)
-                    .mapToObj(index -> ParticipationFixtures.createParticipationEntityWith(PartyFixtures.createPartyEntity(), userId))
+            List<PartyEntity> partyEntities = IntStream.rangeClosed(1, partiesSize)
+                    .mapToObj(index -> PartyFixtures.createPartyEntity())
                     .collect(Collectors.toList());
-            participationEntities.add(ParticipationFixtures.createParticipationEntityWith(PartyFixtures.createTerminatedPartyEntity(), userId));
-            when(participationRepository.findByUserId(userId)).thenReturn(participationEntities);
+            // 종료된 팟 추가
+            partyEntities.add(PartyFixtures.createTerminatedPartyEntity());
+            when(partyRepository.findByParticipationUserId(userId)).thenReturn(partyEntities);
 
             // when
             var parties = partyFinder.findParticipatingParties(UserFixtures.createUser(userId));

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
@@ -1,7 +1,10 @@
 package com.woopaca.taximate.core.domain.chat;
 
+import com.woopaca.taximate.core.domain.user.User;
 import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
+import com.woopaca.taximate.storage.db.core.entity.UserEntity;
 import com.woopaca.taximate.storage.db.core.repository.ChatRepository;
+import com.woopaca.taximate.storage.db.core.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -10,13 +13,18 @@ import org.springframework.stereotype.Component;
 public class ChatAppender {
 
     private final ChatRepository chatRepository;
+    private final UserRepository userRepository;
 
-    public ChatAppender(ChatRepository chatRepository) {
+    public ChatAppender(ChatRepository chatRepository, UserRepository userRepository) {
         this.chatRepository = chatRepository;
+        this.userRepository = userRepository;
     }
 
     public void appendNew(Chat chat) {
-        ChatEntity chatEntity = chat.toEntity();
+        User sender = chat.getSender();
+        UserEntity userEntity = userRepository.findById(sender.getId())
+                .orElse(null);
+        ChatEntity chatEntity = chat.toEntity(userEntity);
         chatRepository.save(chatEntity);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
@@ -1,0 +1,28 @@
+package com.woopaca.taximate.core.domain.chat;
+
+import com.woopaca.taximate.core.domain.party.Party;
+import com.woopaca.taximate.core.domain.user.User;
+import com.woopaca.taximate.storage.db.core.repository.ChatRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatFinder {
+
+    private final ChatRepository chatRepository;
+
+    public ChatFinder(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    public Chat findRecentMessage(Party party) {
+        return chatRepository.findTopByPartyId(party.getId(), Sort.by(Order.desc("id")))
+                .map(entity -> Chat.fromEntity(entity, party))
+                .orElseGet(() -> Chat.empty(party));
+    }
+
+    public int calculateUnreadCount(Party party, User user) {
+        return chatRepository.countByLastChatId(party.getId(), user.getId());
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
@@ -29,8 +29,7 @@ public class ChatReadRecorder {
     public void removeReadHistory(Chat leaveChat) {
         User user = leaveChat.getSender();
         Party party = leaveChat.getParty();
-        chatReadRepository.findByUserIdAndPartyId(user.getId(), party.getId())
-                .ifPresent(chatReadRepository::delete);
+        chatReadRepository.deleteByUserIdAndPartyId(user.getId(), party.getId());
     }
 
     public void recordReadHistory(Chat chat) {
@@ -38,10 +37,6 @@ public class ChatReadRecorder {
     }
 
     public void recordReadHistory(Chat chat, User user) {
-        chatReadRepository.findByUserIdAndPartyId(user.getId(), chat.getParty().getId())
-                .ifPresent(entity -> {
-                    entity.updateLastChatId(chat.getId());
-                    chatReadRepository.save(entity);
-                });
+        chatReadRepository.updateLastChatId(user.getId(), chat.getParty().getId(), chat.getId());
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatRoom.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatRoom.java
@@ -3,6 +3,8 @@ package com.woopaca.taximate.core.domain.chat;
 import com.woopaca.taximate.core.domain.party.Party;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class ChatRoom {
 
@@ -14,5 +16,13 @@ public class ChatRoom {
         this.party = party;
         this.recentMessage = recentMessage;
         this.unreadCount = unreadCount;
+    }
+
+    public Boolean isProgress() {
+        return party.isProgress();
+    }
+
+    public LocalDateTime getRecentMessageTime() {
+        return recentMessage.getSentAt();
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatRoom.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatRoom.java
@@ -1,0 +1,18 @@
+package com.woopaca.taximate.core.domain.chat;
+
+import com.woopaca.taximate.core.domain.party.Party;
+import lombok.Getter;
+
+@Getter
+public class ChatRoom {
+
+    private Party party;
+    private Chat recentMessage;
+    private int unreadCount;
+
+    public ChatRoom(Party party, Chat recentMessage, int unreadCount) {
+        this.party = party;
+        this.recentMessage = recentMessage;
+        this.unreadCount = unreadCount;
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -1,6 +1,9 @@
 package com.woopaca.taximate.core.domain.chat.service;
 
+import com.woopaca.taximate.core.domain.auth.AuthenticatedUserHolder;
 import com.woopaca.taximate.core.domain.chat.Chat;
+import com.woopaca.taximate.core.domain.chat.ChatFinder;
+import com.woopaca.taximate.core.domain.chat.ChatRoom;
 import com.woopaca.taximate.core.domain.chat.MessageNotifier;
 import com.woopaca.taximate.core.domain.error.exception.NotParticipatedPartyException;
 import com.woopaca.taximate.core.domain.event.ChatEventProducer;
@@ -8,6 +11,9 @@ import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.party.PartyFinder;
 import com.woopaca.taximate.core.domain.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class ChatService {
@@ -15,11 +21,13 @@ public class ChatService {
     private final PartyFinder partyFinder;
     private final MessageNotifier messageNotifier;
     private final ChatEventProducer chatEventProducer;
+    private final ChatFinder chatFinder;
 
-    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer) {
+    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer, ChatFinder chatFinder) {
         this.partyFinder = partyFinder;
         this.messageNotifier = messageNotifier;
         this.chatEventProducer = chatEventProducer;
+        this.chatFinder = chatFinder;
     }
 
     public void sendStandardMessage(Long partyId, User sender, String message) {
@@ -30,5 +38,18 @@ public class ChatService {
         Chat chat = Chat.standardMessage(party, sender, message);
         chatEventProducer.publishChatEvent(chat);
         messageNotifier.notify(chat);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoom> getChatRoomList() {
+        User authenticatedUser = AuthenticatedUserHolder.getAuthenticatedUser();
+        List<Party> participatedParties = partyFinder.findAllParticipatedParty(authenticatedUser);
+        return participatedParties.stream()
+                .map(party -> {
+                    Chat recentMessage = chatFinder.findRecentMessage(party);
+                    int unreadCount = chatFinder.calculateUnreadCount(party, authenticatedUser);
+                    return new ChatRoom(party, recentMessage, unreadCount);
+                })
+                .toList();
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -13,6 +13,7 @@ import com.woopaca.taximate.core.domain.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -50,6 +51,8 @@ public class ChatService {
                     int unreadCount = chatFinder.calculateUnreadCount(party, authenticatedUser);
                     return new ChatRoom(party, recentMessage, unreadCount);
                 })
+                .sorted(Comparator.comparing(ChatRoom::isProgress)
+                        .thenComparing(ChatRoom::getRecentMessageTime).reversed())
                 .toList();
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/exception/InvalidRefreshTokenException.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/error/exception/InvalidRefreshTokenException.java
@@ -8,5 +8,6 @@ public class InvalidRefreshTokenException extends BusinessException {
 
     public InvalidRefreshTokenException() {
         super(MESSAGE, ErrorType.INVALID_REFRESH_TOKEN);
+        setStackTrace(new StackTraceElement[]{});
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/Party.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/Party.java
@@ -125,7 +125,7 @@ public class Party {
     }
 
     public boolean isProgress() {
-        return departureTime.isAfter(LocalDateTime.now().minusMinutes(30));
+        return departureTime.isAfter(LocalDateTime.now().minusMinutes(10));
     }
 
     public Party allocateAddress(Address originAddress, Address destinationAddress) {

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
@@ -2,9 +2,7 @@ package com.woopaca.taximate.core.domain.party;
 
 import com.woopaca.taximate.core.domain.error.exception.NonexistentPartyException;
 import com.woopaca.taximate.core.domain.user.User;
-import com.woopaca.taximate.storage.db.core.entity.ParticipationEntity;
 import com.woopaca.taximate.storage.db.core.entity.PartyEntity;
-import com.woopaca.taximate.storage.db.core.repository.ParticipationRepository;
 import com.woopaca.taximate.storage.db.core.repository.PartyRepository;
 import org.springframework.stereotype.Component;
 
@@ -14,11 +12,9 @@ import java.util.List;
 public class PartyFinder {
 
     private final PartyRepository partyRepository;
-    private final ParticipationRepository participationRepository;
 
-    public PartyFinder(PartyRepository partyRepository, ParticipationRepository participationRepository) {
+    public PartyFinder(PartyRepository partyRepository) {
         this.partyRepository = partyRepository;
-        this.participationRepository = participationRepository;
     }
 
     public Party findParty(Long partyId) {
@@ -34,20 +30,15 @@ public class PartyFinder {
     }
 
     public List<Party> findParticipatingParties(User user) {
-        return participationRepository.findByUserId(user.getId())
+        return partyRepository.findByParticipationUserId(user.getId())
                 .stream()
-                .map(ParticipationEntity::getParty)
                 .map(Party::fromEntityExcludeParticipants)
                 .filter(Party::isProgress)
                 .toList();
     }
 
     public List<Party> findAllParticipatedParty(User user) {
-        List<Long> ids = participationRepository.findByUserId(user.getId())
-                .stream()
-                .map(entity -> entity.getParty().getId())
-                .toList();
-        return partyRepository.findByIdIn(ids)
+        return partyRepository.findByParticipationUserId(user.getId())
                 .stream()
                 .map(Party::fromEntity)
                 .toList();

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/party/PartyFinder.java
@@ -41,4 +41,15 @@ public class PartyFinder {
                 .filter(Party::isProgress)
                 .toList();
     }
+
+    public List<Party> findAllParticipatedParty(User user) {
+        List<Long> ids = participationRepository.findByUserId(user.getId())
+                .stream()
+                .map(entity -> entity.getParty().getId())
+                .toList();
+        return partyRepository.findByIdIn(ids)
+                .stream()
+                .map(Party::fromEntity)
+                .toList();
+    }
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/entity/ChatEntity.java
@@ -1,18 +1,16 @@
 package com.woopaca.taximate.storage.db.core.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @Entity(name = "chat")
 public class ChatEntity {
 
@@ -23,25 +21,24 @@ public class ChatEntity {
 
     private String type;
 
-    private Long userId;
+    private LocalDateTime createdAt;
 
     private Long partyId;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(optional = false, targetEntity = UserEntity.class, fetch = FetchType.LAZY)
+    private UserEntity user;
 
     public ChatEntity() {
     }
 
     @Builder
-    public ChatEntity(Long id, String message, String type, Long userId, Long partyId) {
+    public ChatEntity(Long id, String message, String type, LocalDateTime createdAt, Long partyId, UserEntity user) {
         this.id = id;
         this.message = message;
         this.type = type;
-        this.userId = userId;
+        this.createdAt = createdAt;
         this.partyId = partyId;
+        this.user = user;
     }
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
@@ -2,12 +2,22 @@ package com.woopaca.taximate.storage.db.core.repository;
 
 import com.woopaca.taximate.storage.db.core.entity.ChatReadEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface ChatReadRepository extends JpaRepository<ChatReadEntity, Long> {
 
-    Optional<ChatReadEntity> findByUserIdAndPartyId(Long userId, Long partyId);
+    void deleteByUserIdAndPartyId(Long userId, Long partyId);
+
+    @Modifying
+    @Query("""
+            UPDATE chat_read
+            SET lastChatId = :chatId
+            WHERE userId = :userId AND partyId = :partyId
+            AND lastChatId = :chatId
+            """)
+    void updateLastChatId(@Param("userId") Long userId, @Param("partyId") Long partyId, @Param("chatId") Long chatId);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
@@ -2,7 +2,10 @@ package com.woopaca.taximate.storage.db.core.repository;
 
 import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +14,18 @@ import java.util.Optional;
 public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
 
     Optional<ChatEntity> findTopBy(Sort sort);
+
+    @EntityGraph(attributePaths = {"user"})
+    Optional<ChatEntity> findTopByPartyId(Long partyId, Sort sort);
+
+    @Query("""
+            SELECT COUNT(*)
+            FROM chat
+            WHERE id > (SELECT lastChatId
+                        FROM chat_read
+                        WHERE partyId = :partyId
+                          AND userId = :userId)
+            AND partyId = :partyId
+            """)
+    int countByLastChatId(@Param("partyId") Long partyId, @Param("userId") Long userId);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +21,7 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long>, Party
             WHERE p.id = :id
             """)
     Optional<PartyEntity> findByIdWithParticipation(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {"participationSet"})
+    List<PartyEntity> findByIdIn(Collection<Long> ids);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/PartyRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,11 +16,16 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long>, Party
     @EntityGraph(attributePaths = {"participationSet"})
     @Query("""
             SELECT p
-            FROM com.woopaca.taximate.storage.db.core.entity.PartyEntity p
+            FROM party p
             WHERE p.id = :id
             """)
     Optional<PartyEntity> findByIdWithParticipation(@Param("id") Long id);
 
-    @EntityGraph(attributePaths = {"participationSet"})
-    List<PartyEntity> findByIdIn(Collection<Long> ids);
+    @Query("""
+            SELECT DISTINCT p
+            FROM party p
+                JOIN FETCH p.participationSet pt
+            WHERE pt.userId = :userId
+            """)
+    List<PartyEntity> findByParticipationUserId(@Param("userId") Long userId);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/UserRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/UserRepository.java
@@ -15,6 +15,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select u from com.woopaca.taximate.storage.db.core.entity.UserEntity u where u.id = :id")
+    @Query("SELECT u FROM user u WHERE u.id = :id")
     void acquireExclusiveLock(Long id);
 }

--- a/storage/db-core/src/main/resources/db/schema.sql
+++ b/storage/db-core/src/main/resources/db/schema.sql
@@ -61,7 +61,6 @@ CREATE TABLE IF NOT EXISTS `chat`
     `user_id`    BIGINT,
     `party_id`   BIGINT       NOT NULL,
     `created_at` DATETIME     NOT NULL,
-    `updated_at` DATETIME     NOT NULL,
     PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
## 📌 간단 설명

사용자가 참여한 모든 팟의 채팅방 목록을 조회하는 API를 구현

## ✅ 변경 내용

- GET /api/v1/chat 요청 -> 채팅방 목록 조회
- 팟 제목, 최근 메시지, 최근 메시지 시간, 읽지 않은 메시지 수 등 포함
