### PR TITLE
#68 feature: 채팅 내역 조회 API

### DIFF
--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/controller/ChatApiController.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/controller/ChatApiController.java
@@ -1,23 +1,30 @@
 package com.woopaca.taximate.core.api.chat.controller;
 
+import com.woopaca.taximate.core.api.chat.dto.ChatListResponse;
 import com.woopaca.taximate.core.api.chat.dto.ChatRoomResponse;
 import com.woopaca.taximate.core.api.common.model.ApiResults;
 import com.woopaca.taximate.core.api.common.model.ApiResults.ApiResponse;
+import com.woopaca.taximate.core.domain.chat.Chat;
 import com.woopaca.taximate.core.domain.chat.service.ChatService;
+import com.woopaca.taximate.core.domain.party.Party;
+import com.woopaca.taximate.core.domain.party.PartyFinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@RequestMapping("/api/v1/chat")
+@RequestMapping("/api/v1/chats")
 @RestController
 public class ChatApiController {
 
     private final ChatService chatService;
+    private final PartyFinder partyFinder;
 
-    public ChatApiController(ChatService chatService) {
+    public ChatApiController(ChatService chatService, PartyFinder partyFinder) {
         this.chatService = chatService;
+        this.partyFinder = partyFinder;
     }
 
     @GetMapping
@@ -26,6 +33,14 @@ public class ChatApiController {
                 .stream()
                 .map(ChatRoomResponse::from)
                 .toList();
+        return ApiResults.success(response);
+    }
+
+    @GetMapping("/{partyId}")
+    public ApiResponse<ChatListResponse> chatList(@PathVariable("partyId") Long partyId) {
+        Party party = partyFinder.findParty(partyId);
+        List<Chat> chats = chatService.getChats(party);
+        ChatListResponse response = ChatListResponse.of(party, chats);
         return ApiResults.success(response);
     }
 }

--- a/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/dto/ChatListResponse.java
+++ b/core/core-api/src/main/java/com/woopaca/taximate/core/api/chat/dto/ChatListResponse.java
@@ -1,0 +1,51 @@
+package com.woopaca.taximate.core.api.chat.dto;
+
+import com.woopaca.taximate.core.api.party.dto.response.PartiesResponse;
+import com.woopaca.taximate.core.domain.chat.Chat;
+import com.woopaca.taximate.core.domain.chat.MessageType;
+import com.woopaca.taximate.core.domain.party.Party;
+import com.woopaca.taximate.core.domain.user.User;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ChatListResponse(PartiesResponse party, List<ChatResponse> chats) {
+
+    public static ChatListResponse of(Party party, List<Chat> chats) {
+        List<ChatResponse> chatResponses = chats.stream()
+                .map(ChatResponse::from)
+                .toList();
+        PartiesResponse partiesResponse = PartiesResponse.from(party);
+        return new ChatListResponse(partiesResponse, chatResponses);
+    }
+
+    @Builder
+    record ChatResponse(Long id, String message, MessageType type, LocalDateTime createdAt, Sender sender) {
+
+        public static ChatResponse from(Chat chat) {
+            User user = chat.getSender();
+            Sender sender = Sender.from(user);
+            return ChatResponse.builder()
+                    .id(chat.getId())
+                    .message(chat.getMessage())
+                    .type(chat.getType())
+                    .createdAt(chat.getSentAt())
+                    .sender(sender)
+                    .build();
+        }
+    }
+
+    @Builder
+    record Sender(Long id, String nickname, String profileImage, boolean isMe) {
+
+        public static Sender from(User user) {
+            return Sender.builder()
+                    .id(user.getId())
+                    .nickname(user.getNickname())
+                    .profileImage(user.getProfileImage())
+                    .isMe(user.isCurrentUser())
+                    .build();
+        }
+    }
+}

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatAppender.java
@@ -3,28 +3,30 @@ package com.woopaca.taximate.core.domain.chat;
 import com.woopaca.taximate.core.domain.user.User;
 import com.woopaca.taximate.storage.db.core.entity.ChatEntity;
 import com.woopaca.taximate.storage.db.core.entity.UserEntity;
-import com.woopaca.taximate.storage.db.core.repository.ChatRepository;
 import com.woopaca.taximate.storage.db.core.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 public class ChatAppender {
 
-    private final ChatRepository chatRepository;
     private final UserRepository userRepository;
+    private final EntityManager entityManager;
 
-    public ChatAppender(ChatRepository chatRepository, UserRepository userRepository) {
-        this.chatRepository = chatRepository;
+    public ChatAppender(UserRepository userRepository, EntityManager entityManager) {
         this.userRepository = userRepository;
+        this.entityManager = entityManager;
     }
 
+    @Transactional
     public void appendNew(Chat chat) {
         User sender = chat.getSender();
         UserEntity userEntity = userRepository.findById(sender.getId())
                 .orElse(null);
         ChatEntity chatEntity = chat.toEntity(userEntity);
-        chatRepository.save(chatEntity);
+        entityManager.persist(chatEntity);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
@@ -29,7 +29,7 @@ public class ChatFinder {
     }
 
     public List<Chat> findChats(Party party) {
-        return chatRepository.findByPartyId(party.getId(), Sort.by(Order.desc("id")))
+        return chatRepository.findByPartyId(party.getId(), Sort.by("id"))
                 .stream()
                 .map(entity -> Chat.fromEntity(entity, party))
                 .toList();

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatFinder.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class ChatFinder {
 
@@ -24,5 +26,12 @@ public class ChatFinder {
 
     public int calculateUnreadCount(Party party, User user) {
         return chatRepository.countByLastChatId(party.getId(), user.getId());
+    }
+
+    public List<Chat> findChats(Party party) {
+        return chatRepository.findByPartyId(party.getId(), Sort.by(Order.desc("id")))
+                .stream()
+                .map(entity -> Chat.fromEntity(entity, party))
+                .toList();
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/ChatReadRecorder.java
@@ -5,7 +5,9 @@ import com.woopaca.taximate.core.domain.user.User;
 import com.woopaca.taximate.storage.db.core.entity.ChatReadEntity;
 import com.woopaca.taximate.storage.db.core.repository.ChatReadRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Component
 public class ChatReadRecorder {
 

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -71,7 +71,7 @@ public class ChatService {
         if (chats.isEmpty()) {
             return Collections.emptyList();
         }
-        chatReadRecorder.recordReadHistory(chats.get(0), authenticatedUser);
+        chatReadRecorder.recordReadHistory(chats.get(chats.size() - 1), authenticatedUser);
         return chats;
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.woopaca.taximate.core.domain.chat.service;
 import com.woopaca.taximate.core.domain.auth.AuthenticatedUserHolder;
 import com.woopaca.taximate.core.domain.chat.Chat;
 import com.woopaca.taximate.core.domain.chat.ChatFinder;
+import com.woopaca.taximate.core.domain.chat.ChatReadRecorder;
 import com.woopaca.taximate.core.domain.chat.ChatRoom;
 import com.woopaca.taximate.core.domain.chat.MessageNotifier;
 import com.woopaca.taximate.core.domain.error.exception.NotParticipatedPartyException;
@@ -13,6 +14,7 @@ import com.woopaca.taximate.core.domain.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -23,12 +25,14 @@ public class ChatService {
     private final MessageNotifier messageNotifier;
     private final ChatEventProducer chatEventProducer;
     private final ChatFinder chatFinder;
+    private final ChatReadRecorder chatReadRecorder;
 
-    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer, ChatFinder chatFinder) {
+    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer, ChatFinder chatFinder, ChatReadRecorder chatReadRecorder) {
         this.partyFinder = partyFinder;
         this.messageNotifier = messageNotifier;
         this.chatEventProducer = chatEventProducer;
         this.chatFinder = chatFinder;
+        this.chatReadRecorder = chatReadRecorder;
     }
 
     public void sendStandardMessage(Long partyId, User sender, String message) {
@@ -54,5 +58,20 @@ public class ChatService {
                 .sorted(Comparator.comparing(ChatRoom::isProgress)
                         .thenComparing(ChatRoom::getRecentMessageTime).reversed())
                 .toList();
+    }
+
+    @Transactional
+    public List<Chat> getChats(Party party) {
+        User authenticatedUser = AuthenticatedUserHolder.getAuthenticatedUser();
+        if (!party.isParticipated(authenticatedUser)) {
+            throw new NotParticipatedPartyException();
+        }
+
+        List<Chat> chats = chatFinder.findChats(party);
+        if (chats.isEmpty()) {
+            return Collections.emptyList();
+        }
+        chatReadRecorder.recordReadHistory(chats.get(0), authenticatedUser);
+        return chats;
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/event/ChatEventConsumer.java
@@ -6,6 +6,7 @@ import com.woopaca.taximate.core.domain.chat.ChatReadRecorder;
 import com.woopaca.taximate.core.domain.event.dto.ChatEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class ChatEventConsumer {
@@ -18,6 +19,7 @@ public class ChatEventConsumer {
         this.chatReadRecorder = chatReadRecorder;
     }
 
+    @Transactional
     @EventListener
     public void handleChatEvent(ChatEvent chatEvent) {
         Chat chat = chatEvent.chat();

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatReadRepository.java
@@ -17,7 +17,7 @@ public interface ChatReadRepository extends JpaRepository<ChatReadEntity, Long> 
             UPDATE chat_read
             SET lastChatId = :chatId
             WHERE userId = :userId AND partyId = :partyId
-            AND lastChatId = :chatId
+            AND lastChatId < :chatId
             """)
     void updateLastChatId(@Param("userId") Long userId, @Param("partyId") Long partyId, @Param("chatId") Long chatId);
 }

--- a/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
+++ b/storage/db-core/src/main/java/com/woopaca/taximate/storage/db/core/repository/ChatRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -28,4 +29,7 @@ public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
             AND partyId = :partyId
             """)
     int countByLastChatId(@Param("partyId") Long partyId, @Param("userId") Long userId);
+
+    @EntityGraph(attributePaths = {"user"})
+    List<ChatEntity> findByPartyId(Long partyId, Sort sort);
 }


### PR DESCRIPTION
## 📌 간단 설명

팟의 채팅 내역을 조회한다.

## ✅ 변경 내용

- 팟 채팅 내역 조회 기능
- 마지막 채팅 ID로 채팅 읽음 기록 갱신
