### PR TITLE
#69 feature: 채팅 읽음 기록 실시간 갱신

### DIFF
--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/chat/service/ChatService.java
@@ -11,6 +11,7 @@ import com.woopaca.taximate.core.domain.event.ChatEventProducer;
 import com.woopaca.taximate.core.domain.party.Party;
 import com.woopaca.taximate.core.domain.party.PartyFinder;
 import com.woopaca.taximate.core.domain.user.User;
+import com.woopaca.taximate.storage.db.core.repository.ChatReadRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,13 +27,15 @@ public class ChatService {
     private final ChatEventProducer chatEventProducer;
     private final ChatFinder chatFinder;
     private final ChatReadRecorder chatReadRecorder;
+    private final ChatReadRepository chatReadRepository;
 
-    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer, ChatFinder chatFinder, ChatReadRecorder chatReadRecorder) {
+    public ChatService(PartyFinder partyFinder, MessageNotifier messageNotifier, ChatEventProducer chatEventProducer, ChatFinder chatFinder, ChatReadRecorder chatReadRecorder, ChatReadRepository chatReadRepository) {
         this.partyFinder = partyFinder;
         this.messageNotifier = messageNotifier;
         this.chatEventProducer = chatEventProducer;
         this.chatFinder = chatFinder;
         this.chatReadRecorder = chatReadRecorder;
+        this.chatReadRepository = chatReadRepository;
     }
 
     public void sendStandardMessage(Long partyId, User sender, String message) {
@@ -73,5 +76,10 @@ public class ChatService {
         }
         chatReadRecorder.recordReadHistory(chats.get(chats.size() - 1), authenticatedUser);
         return chats;
+    }
+
+    @Transactional
+    public void receiveMessage(Long partyId, Long chatId, User receiver) {
+        chatReadRepository.updateLastChatId(receiver.getId(), partyId, chatId);
     }
 }

--- a/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/user/UserFinder.java
+++ b/core/core-domain/src/main/java/com/woopaca/taximate/core/domain/user/UserFinder.java
@@ -22,6 +22,7 @@ public class UserFinder {
         return User.fromEntity(userEntity);
     }
 
+    // TODO cache 적용
     public Optional<User> findUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .map(User::fromEntity);

--- a/core/core-message/src/main/java/com/woopaca/taximate/core/message/controller/ChatController.java
+++ b/core/core-message/src/main/java/com/woopaca/taximate/core/message/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.woopaca.taximate.core.message.controller;
 import com.woopaca.taximate.core.domain.chat.service.ChatService;
 import com.woopaca.taximate.core.domain.user.User;
 import com.woopaca.taximate.core.message.HeaderAccessorManipulator;
+import com.woopaca.taximate.core.message.dto.ReceivedChat;
 import com.woopaca.taximate.core.message.dto.SendChat;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -26,5 +27,12 @@ public class ChatController {
         HeaderAccessorManipulator accessorManipulator = HeaderAccessorManipulator.wrap(accessor);
         User sender = accessorManipulator.getUser();
         chatService.sendStandardMessage(sendChat.partyId(), sender, sendChat.message());
+    }
+
+    @MessageMapping("/received")
+    public void receivedMessage(@Validated @Payload ReceivedChat receivedChat, StompHeaderAccessor accessor) {
+        HeaderAccessorManipulator accessorManipulator = HeaderAccessorManipulator.wrap(accessor);
+        User receiver = accessorManipulator.getUser();
+        chatService.receiveMessage(receivedChat.partyId(), receivedChat.chatId(), receiver);
     }
 }

--- a/core/core-message/src/main/java/com/woopaca/taximate/core/message/dto/ReceivedChat.java
+++ b/core/core-message/src/main/java/com/woopaca/taximate/core/message/dto/ReceivedChat.java
@@ -1,0 +1,4 @@
+package com.woopaca.taximate.core.message.dto;
+
+public record ReceivedChat(Long partyId, Long chatId) {
+}


### PR DESCRIPTION
## 📌 간단 설명

사용자가 채팅방에서 메시지를 수신하면 채팅 읽음 기록을 실시간으로 갱신한다.

## ✅ 변경 내용

- `SEND /app/received`로 전달된 WebSocket(STOMP) 메시지 처리
- 즉시 사용자의 채팅 읽음 기록을 갱신
